### PR TITLE
Restrict keyword arguments in RESTART-BIND bindings

### DIFF
--- a/src/restarts.lisp
+++ b/src/restarts.lisp
@@ -4,10 +4,13 @@
 
 ;;; Restart definition
 
-(defstruct restart
+(defstruct (restart
+            (:constructor make-restart
+                (name function
+                 &key report-function interactive-function test-function)))
   "A restart structure, implementing the ANSI CL system class RESTART."
-  (name (error "NAME required."))
-  (function (error "FUNCTION required."))
+  (name)
+  (function)
   (report-function nil)
   (interactive-function nil)
   (test-function (constantly t))
@@ -153,8 +156,7 @@ apply the restart functions to them."
 
 (defun restart-bind-transform-binding (binding)
   "Transforms the RESTART-BIND binding into a MAKE-RESTART form."
-  (destructuring-bind (name function . arguments) binding
-    `(make-restart :name ',name :function ,function ,@arguments)))
+  `(make-restart ,@binding))
 
 (defmacro restart-bind (bindings &body body)
   "Executes the body forms in a dynamic context where the newly established


### PR DESCRIPTION
In the current implementation, `:function` or `:name` could be specified as keyword arguments in bindings of a `restart-bind` form which, while harmless, is almost certainly a mistake since their values would be overridden by the supplied function or restart name; `:associated-conditions` can also be specified and I am unsure if this is desirable or not, but this pull request disallows it.